### PR TITLE
Upgrade deprecated runtime nodejs14.x

### DIFF
--- a/artifacts/dependencies/botocore/data/lambda/2015-03-31/service-2.json
+++ b/artifacts/dependencies/botocore/data/lambda/2015-03-31/service-2.json
@@ -4254,7 +4254,7 @@
         "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
-        "nodejs14.x",
+        "nodejs16.x",
         "java8",
         "java8.al2",
         "java11",


### PR DESCRIPTION
CloudFormation templates in aws-iot-greengrass-component-lorawan-provisioning have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs14.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.